### PR TITLE
投稿したコメントが詳細ページで表示されるようにしましょう

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -10,10 +10,6 @@ class CommentsController < ApplicationController
     end
   end
 
-  def show
-    @comments = Comment.all
-  end
-
   private
   def comment_params
     params.require(:comment).permit(:content).merge(user_id: current_user.id, prototype_id: params[:prototype_id])

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -20,6 +20,7 @@ class PrototypesController < ApplicationController
   def show
     @prototype = Prototype.find(params[:id])
     @comment = Comment.new
+    @comments = Comment.all
   end
 
   def edit

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -47,8 +47,12 @@
         <ul class="comments_lists">
           <%# 投稿に紐づくコメントを一覧する処理を記述する %>
             <li class="comments_list">
-              <%# <%= " コメントのテキスト "%>
-              <%# <%= link_to "（ ユーザー名 ）", root_path, class: :comment_user %>
+              <% @comments.each do |comment| %>
+              <p>
+              <%=comment.content%>
+              <%= link_to comment.user.name, root_path, class: :comment_user %>
+              </p>
+              <% end %> 
             </li>
           <%# // 投稿に紐づくコメントを一覧する処理を記述する %>
         </ul>


### PR DESCRIPTION
what
投稿したコメントが詳細ページで表示されるようにしました。


why
詳細ページに投稿に紐づくユーザー名とコメントを一覧で表示できるようにしました。
プロトタイプコントローラーのshowアクションに記述を追加しました。
コメントコントローラーのshowアクションが不要と判明したので、削除を実施しました。